### PR TITLE
remove } character duplicate

### DIFF
--- a/toc.yaml
+++ b/toc.yaml
@@ -29,10 +29,10 @@ toc:
           - tutorials/secure-import.md
           - link: 
             label: Apply end to end security to a cloud application
-            href: https://{DomainName}}/docs/tutorials?topic=solution-tutorials-cloud-e2e-security
+            href: https://{DomainName}/docs/tutorials?topic=solution-tutorials-cloud-e2e-security
           - link: 
             label: Enhance security of your deployed application
-            href: https://{DomainName}}/docs/tutorials?topic=solution-tutorials-extended-app-security
+            href: https://{DomainName}/docs/tutorials?topic=solution-tutorials-extended-app-security
       - topicgroup: 
           label: Integrations
           topics: 


### PR DESCRIPTION
Hi,
I'm on the page https://cloud.ibm.com/docs/key-protect?topic=key-protect-tutorial-import-keys
When I clicked on "Tutorial: Creating and importing encryption keys" and "Apply end to end security to a cloud application" both URLs have %7D which is the ASCII code for the } character such as "https://cloud.ibm.com%7D/docs/tutorials". 
![Screen Shot 2021-11-08 at 16 20 10](https://user-images.githubusercontent.com/2862839/140804471-945328e2-aa70-4b05-b879-fc6fb4cc5066.png)

I fixed the issue removing } character duplicate

